### PR TITLE
Added support for naming of the containers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,14 +50,14 @@ Save the content below to test.yml
 
 - container:
     image: busybox
-    name: test
+    id: test
     command: ["echo", "hello world"]
 
 - follow:
-  name: test
+  id: test
 
 - remove:
-  name: test
+  id: test
 ~~~
 Run the command:
 ~~~
@@ -154,11 +154,12 @@ The build plugin support basic building and removal of images.
 ~~~
 
 ## Container
-The container plugin has four regular config options where two is mandatory. The advanced section is a direct translation of the [dockerpy](https://docker-py.readthedocs.io/en/stable/) clients create functions arguments but few are tested, see the [advanced](#advanced) section for more information.
-- **name:** name of container inside milk, mandatory
+The container plugin has five regular config options where two is mandatory. The advanced section is a direct translation of the [dockerpy](https://docker-py.readthedocs.io/en/stable/) clients create functions arguments but few are tested, see the [advanced](#advanced) section for more information.
+- **id:** name of container within milk, mandatory
 - **image:** name of image, mandatory
 - **command:** command to execute, does not override entrypoint settings, optional
 - **detach:** set to True to have the container run in detached mode
+- **name:** name of container in docker
 
 See the [basic example](#basic-example) how to start a simple container.
 
@@ -210,7 +211,7 @@ This will copy from the host to a container before the container have started
 ~~~yaml
 - container:
     image: busybox
-    name: test
+    id: test
     copy:
       src: folder/file
       dest: folder/file
@@ -242,7 +243,7 @@ Follow is like tail -f on the containers stdout. You can only follow one contain
 
 ~~~yaml
 - follow:
-    name: mycontainer
+    id: mycontainer
 ~~~
 
 ## Remove
@@ -250,7 +251,7 @@ Remove is used to remove an container after or when it is running, You can use t
 
 ~~~yaml
 - remove:
-    name: mycontainer
+    id: mycontainer
     force: True
 ~~~
 

--- a/tests/te_sut.conf
+++ b/tests/te_sut.conf
@@ -7,7 +7,7 @@
     required: False
 
 - container:
-    name: sut
+    id: sut
     image: "ubuntu:16.04"
     command: "sleep 30"
 
@@ -15,7 +15,7 @@
       detach: True
 
 - container:
-    name: te
+    id: te
     image: "ping"
     command: ["ping", "-c", "5", "sut"]
 
@@ -30,16 +30,16 @@
           example: 10.0.0.1
 
 - follow:
-    name: te
+    id: te
 
 - copy:
     src: "te:/from.txt"
     dest: "tests/banan.txt"
 
 - remove:
-    name: te
+    id: te
 
 - remove:
-    name: sut
+    id: sut
     force: True
 

--- a/tests/test_milk.py
+++ b/tests/test_milk.py
@@ -69,7 +69,7 @@ def test_create_assign_remove_network(capfd):
     driver: bridge
 
 - container:
-    name: test
+    id: test
     image: ping
     command: "sleep 300"
     detach: True
@@ -81,7 +81,7 @@ def test_create_assign_remove_network(capfd):
     text: "<test>{{ test.inspect.NetworkSettings.Networks.my_network.Gateway }}</test>"
 
 - container:
-    name: test1
+    id: test1
     image: ping
     command: "sleep 300"
     detach: True
@@ -93,11 +93,11 @@ def test_create_assign_remove_network(capfd):
     text: "<test1>{{ test1.inspect.NetworkSettings.Networks.my_network.Gateway }}</test1>"
 
 - remove:
-    name: test
+    id: test
     force: true
 
 - remove:
-    name: test1
+    id: test1
     force: true
 
 - network:
@@ -125,15 +125,15 @@ def test_build_image(capfd):
       path: ./tests/
 
 - container:
-    name: buildtest
+    id: buildtest
     image: "ping:test_version"
     command: ["ping", "-c", "5", "localhost"]
 
 - follow:
-    name: buildtest
+    id: buildtest
 
 - remove:
-    name: buildtest
+    id: buildtest
 
 - image:
     remove: "ping:test_version"
@@ -163,13 +163,13 @@ def test_copy_from_host_to_from_from_to_to_to_to_host():
 - version: 1
 
 - container:
-    name: to
+    id: to
     image: "ubuntu:16.04"
     command: "sleep 300"
     detach: True
 
 - container:
-    name: from
+    id: from
     image: "ping"
     command: "sleep 300"
     detach: True
@@ -187,11 +187,11 @@ def test_copy_from_host_to_from_from_to_to_to_to_host():
     dest: /tmp/tests/from_to.txt
 
 - remove:
-    name: from
+    id: from
     force: True
 
 - remove:
-    name: to
+    id: to
     force: True
 
     '''
@@ -266,13 +266,13 @@ def test_ping_from_container(capfd):
     required: False
 
 - container:
-    name: to
+    id: to
     image: "ubuntu:16.04"
     command: "sleep 30"
     detach: True
 
 - container:
-    name: from
+    id: from
     image: "ping"
     command: ["ping", "-c", "5", "to"]
 
@@ -283,13 +283,13 @@ def test_ping_from_container(capfd):
       working_dir: /
 
 - follow:
-    name: from
+    id: from
 
 - remove:
-    name: from
+    id: from
 
 - remove:
-    name: to
+    id: to
     force: True
     '''
     Milk(arguments=["--example", "10.0.0.1"], config=config)
@@ -302,7 +302,7 @@ def test_copy_single_file_from_container(capfd):
     config = '''
 - version: 1
 - container:
-    name: test
+    id: test
     image: ping
     command: 'ls -la /tmp/'
     copy:
@@ -310,14 +310,14 @@ def test_copy_single_file_from_container(capfd):
       dest: /tmp
 
 - follow:
-    name: test
+    id: test
 
 - copy:
     src: test:/tmp/from.txt
     dest: /tmp/tests/tmp/test.txt
 
 - remove:
-    name: test
+    id: test
 
     '''
 


### PR DESCRIPTION
Renamed the "name" config option to "id" and then added support to use "name" to set a unique name for the created container in docker, otherwise the default docker random naming is used   